### PR TITLE
1.2 - Drop settings in GUI

### DIFF
--- a/src/main/java/dawidos506/ddrops/Main.java
+++ b/src/main/java/dawidos506/ddrops/Main.java
@@ -1,5 +1,8 @@
 package dawidos506.ddrops;
 
+import dawidos506.ddrops.commands.CommandDrop;
+import dawidos506.ddrops.guis.GuiMain;
+import dawidos506.ddrops.guis.GuiSettings;
 import dawidos506.ddrops.listeners.BlockBreakListener;
 import dawidos506.ddrops.listeners.PlayerJoinListener;
 import dawidos506.ddrops.managers.DropsManager;
@@ -34,10 +37,16 @@ public final class Main extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
         getServer().getPluginManager().registerEvents(new BlockBreakListener(), this);
+        getServer().getPluginManager().registerEvents(new GuiMain(), this);
+        getServer().getPluginManager().registerEvents(new GuiSettings(), this);
+
+        getCommand("drop").setExecutor(new CommandDrop());
     }
 
     @Override
-    public void onDisable() {}
+    public void onDisable() {
+        userManager.save();
+    }
 
     public List<Drop> getDrops() {
         return drops;

--- a/src/main/java/dawidos506/ddrops/commands/CommandDrop.java
+++ b/src/main/java/dawidos506/ddrops/commands/CommandDrop.java
@@ -1,0 +1,34 @@
+package dawidos506.ddrops.commands;
+
+import dawidos506.ddrops.guis.GuiMain;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class CommandDrop implements CommandExecutor {
+
+    private GuiMain guiMain;
+
+    public CommandDrop() {
+        guiMain = new GuiMain();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if(command.getName().equalsIgnoreCase("drop")) {
+            if(!(sender instanceof Player)) {
+
+            }
+            else {
+                Player p = (Player) sender;
+                if(!p.isOp() || args.length == 0) {
+                    guiMain.openGui(p.getUniqueId());
+                }
+            }
+        }
+        return false;
+    }
+
+
+}

--- a/src/main/java/dawidos506/ddrops/guis/GuiMain.java
+++ b/src/main/java/dawidos506/ddrops/guis/GuiMain.java
@@ -1,0 +1,53 @@
+package dawidos506.ddrops.guis;
+
+import dawidos506.ddrops.utils.ChatUtil;
+import dawidos506.ddrops.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
+
+public class GuiMain implements Listener {
+
+    private GuiSettings guiSettings;
+
+    private Inventory eq = Bukkit.createInventory(null, 54, ChatUtil.fixColor("§c&ldDrops&b           by dawidos506"));
+
+
+    public void openGui(UUID uuid) {
+        guiSettings = new GuiSettings();
+        Player p = Bukkit.getPlayer(uuid);
+
+        eq.setItem(13, new ItemBuilder(Material.NETHERITE_PICKAXE, 1).setTitle("&b&lStatystyki gracza").addLore("&7Kliknij, aby zobaczyc swoje statystyki.").build());
+        eq.setItem(20, new ItemBuilder(Material.DRAGON_HEAD, 1).setTitle("&b&lRanking").addLore("&7Kliknij, aby zobaczyc ranking serwera.").build());
+        eq.setItem(24, new ItemBuilder(Material.PAINTING, 1).setTitle("&b&lUstawienia").addLore("&7Kliknij, aby przejsc do ustawien.").build());
+        if(p.isOp())
+            eq.setItem(40, new ItemBuilder(Material.BARRIER, 1).setTitle("&c&lAdmin Panel").addLore("&7Kliknij, aby przejsc do panelu admina.").build());
+
+        p.openInventory(eq);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        guiSettings = new GuiSettings();
+        Player p = (Player)e.getWhoClicked();
+        Inventory inv = e.getClickedInventory();
+        ItemStack is = e.getCurrentItem();
+
+        if(e.getView().getTitle().equals(ChatUtil.fixColor("§c&ldDrops&b           by dawidos506"))) {
+            e.setCancelled(true);
+            if(is != null) {
+                if(is.getType().equals(Material.PAINTING)) {
+                    guiSettings.openGui(p.getUniqueId());
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/dawidos506/ddrops/guis/GuiSettings.java
+++ b/src/main/java/dawidos506/ddrops/guis/GuiSettings.java
@@ -1,0 +1,122 @@
+package dawidos506.ddrops.guis;
+
+import dawidos506.ddrops.Main;
+import dawidos506.ddrops.managers.UserManager;
+import dawidos506.ddrops.objects.Drop;
+import dawidos506.ddrops.objects.User;
+import dawidos506.ddrops.utils.ChatUtil;
+import dawidos506.ddrops.utils.ItemBuilder;
+import dawidos506.ddrops.utils.PlayerUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemMergeEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class GuiSettings implements Listener {
+
+    private Main pl = Main.getPlugin(Main.class);
+    private UserManager userManager;
+
+    private Inventory eq = Bukkit.createInventory(null, 54, ChatUtil.fixColor("§c&ldDrops&c - Ustawienia"));
+
+    public void openGui(UUID uuid) {
+        userManager = new UserManager();
+        Player p = Bukkit.getPlayer(uuid);
+        User user = userManager.get(uuid);
+
+        int temp = 0;
+        for(Drop d : pl.getDrops()) {
+            ItemStack drop = d.getDrop();
+            ItemMeta im = drop.getItemMeta();
+            im.setDisplayName(ChatUtil.fixColor(d.getName()));
+            List<String> lore = new ArrayList<>(); {
+                lore.add(ChatUtil.fixColor("&7Ilosc: &b" + d.getAmount()));
+                lore.add(ChatUtil.fixColor("&7Szansa: &b" + d.getChance()));
+                lore.add(ChatUtil.fixColor("&7Min Y: &b" + d.getMinY()));
+                lore.add(ChatUtil.fixColor("&7Max Y: &b" + d.getMaxY()));
+            }
+            im.setLore(lore);
+            drop.setItemMeta(im);
+            eq.setItem(temp, drop);
+            temp++;
+        }
+
+        ItemStack playerHead = PlayerUtils.getPlayerSkull(uuid); {
+            ItemMeta im = playerHead.getItemMeta();
+            im.setDisplayName(ChatUtil.fixColor("&bPrzedmioty trafiaja do ekwipunku"));
+            List<String> lore = new ArrayList<>();
+            if(user.isInv())
+                lore.add(ChatUtil.fixColor("&7Wlaczone: &aTAK"));
+            else
+                lore.add(ChatUtil.fixColor("&7Wlaczone: &cNIE"));
+            im.setLore(lore);
+            playerHead.setItemMeta(im);
+        }
+        ItemStack cobble = new ItemBuilder(Material.COBBLESTONE, 1).setTitle("&bDrop cobblestone").build(); {
+            ItemMeta im = cobble.getItemMeta();
+            List<String> lore = new ArrayList<>();
+            if(user.isCobble())
+                lore.add(ChatUtil.fixColor("&7Wlaczone: &aTAK"));
+            else
+                lore.add(ChatUtil.fixColor("&7Wlaczone: &cNIE"));
+            im.setLore(lore);
+            cobble.setItemMeta(im);
+        }
+        ItemStack msg = new ItemBuilder(Material.OAK_SIGN, 1).setTitle("&bWiadomosci").build(); {
+            ItemMeta im = msg.getItemMeta();
+            List<String> lore = new ArrayList<>();
+            if(user.isMsg())
+                lore.add(ChatUtil.fixColor("&7Wlaczone: &aTAK"));
+            else
+                lore.add(ChatUtil.fixColor("&7Wlaczone: &cNIE"));
+            im.setLore(lore);
+            msg.setItemMeta(im);
+        }
+
+        eq.setItem(48, playerHead);
+        eq.setItem(49, cobble);
+        eq.setItem(50, msg);
+
+        p.openInventory(eq);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        userManager = new UserManager();
+
+        Player p = (Player)e.getWhoClicked();
+        Inventory inv = e.getClickedInventory();
+        ItemStack is = e.getCurrentItem();
+        User user = userManager.get(p.getUniqueId());
+
+        if(e.getView().getTitle().equals(ChatUtil.fixColor("§c&ldDrops&c - Ustawienia"))) {
+            e.setCancelled(true);
+            if(is != null) {
+                if(is.getType().equals(Material.PLAYER_HEAD)) {
+                    user.setInv(!user.isInv());
+                    openGui(p.getUniqueId());
+                }
+                else if(is.getType().equals(Material.COBBLESTONE)) {
+                    user.setCobble(!user.isCobble());
+                    openGui(p.getUniqueId());
+                }
+                else if(is.getType().equals(Material.OAK_SIGN)) {
+                    user.setMsg(!user.isMsg());
+                    openGui(p.getUniqueId());
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/dawidos506/ddrops/listeners/BlockBreakListener.java
+++ b/src/main/java/dawidos506/ddrops/listeners/BlockBreakListener.java
@@ -3,7 +3,11 @@ package dawidos506.ddrops.listeners;
 import dawidos506.ddrops.Main;
 import dawidos506.ddrops.managers.DropsManager;
 import dawidos506.ddrops.managers.FileManager;
+import dawidos506.ddrops.managers.UserManager;
 import dawidos506.ddrops.objects.Drop;
+import dawidos506.ddrops.objects.User;
+import dawidos506.ddrops.utils.ChatUtil;
+import dawidos506.ddrops.utils.ItemBuilder;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -19,22 +23,45 @@ import java.util.concurrent.ThreadLocalRandom;
 public class BlockBreakListener implements Listener {
 
     private Main pl = Main.getPlugin(Main.class);
+    private UserManager userManager;
 
     @EventHandler
     public void onBreak(BlockBreakEvent e) {
+        userManager = new UserManager();
         Player p = e.getPlayer();
         Block block = e.getBlock();
+        User user = userManager.get(p.getUniqueId());
 
         if(p.getGameMode().equals(GameMode.SURVIVAL)) {
             if(block.getType().equals(Material.STONE)) {
                 double random = ThreadLocalRandom.current().nextDouble(0, 100);
+
+
+                if(!user.isCobble()) {
+                    e.setCancelled(true);
+                    block.setType(Material.AIR);
+                }
+                else if(user.isCobble() && user.isInv()) {
+                    e.setCancelled(true);
+                    block.setType(Material.AIR);
+                    p.getInventory().addItem(new ItemBuilder(Material.COBBLESTONE, 1).build());
+                }
+
+
                 for(Drop d : pl.getDrops()) {
                     if(block.getY() >= d.getMinY() && block.getY() <= d.getMaxY()) {
                         if(random <= d.getChance()) {
                             ItemStack drop = d.getDrop();
                             drop.setAmount(d.getAmount());
-                            p.getWorld().dropItemNaturally(block.getLocation(), drop);
-                            p.sendMessage("§4Udalo ci sie wydropic " + d.getName());
+                            if(user.isInv()) {
+                                p.getInventory().addItem(drop);
+                            }
+                            else {
+                                p.getWorld().dropItemNaturally(block.getLocation(), drop);
+                            }
+                            if(user.isMsg()) {
+                                p.sendMessage(ChatUtil.fixColor("&bUdalo ci sie wydropic " + d.getName() + "&b!"));
+                            }
                         }
                     }
                 }

--- a/src/main/java/dawidos506/ddrops/managers/DropsManager.java
+++ b/src/main/java/dawidos506/ddrops/managers/DropsManager.java
@@ -23,7 +23,7 @@ public class DropsManager {
         if(dropsYml != null) {
             if(dropsYml.getConfigurationSection("drops") != null) {
                 for(String s : dropsYml.getConfigurationSection("drops").getKeys(false)) {
-                    Drop drop = new Drop(new ItemBuilder(Material.getMaterial(s), 1).build(), dropsYml.getInt("drops." + s + ".amount"), dropsYml.getDouble("drops." + s + ".chance"), dropsYml.getString("drops."+s+".name"), dropsYml.getInt("drops."+s+".minY"), dropsYml.getInt("drops."+s+".maxY"));
+                    Drop drop = new Drop(new ItemBuilder(Material.getMaterial(s), 1).build(), dropsYml.getInt("drops."+s+".id"), dropsYml.getInt("drops." + s + ".amount"), dropsYml.getDouble("drops." + s + ".chance"), dropsYml.getString("drops."+s+".name"), dropsYml.getInt("drops."+s+".minY"), dropsYml.getInt("drops."+s+".maxY"));
                     pl.drops.add(drop);
                 }
             }

--- a/src/main/java/dawidos506/ddrops/managers/UserManager.java
+++ b/src/main/java/dawidos506/ddrops/managers/UserManager.java
@@ -54,8 +54,16 @@ public class UserManager {
         save();
     }
 
+    public User get(UUID uuid) {
+        for(User u : pl.getUsers()) {
+            if(u.getUuid().equals(uuid)) {
+                return u;
+            }
+        }
+        return null;
+    }
+
     public boolean exists(UUID uuid) {
-        YamlConfiguration usersYml = fileManager.getUsersYml();
         for(User u : pl.getUsers()) {
             if(u.getUuid().equals(uuid)) {
                 return true;

--- a/src/main/java/dawidos506/ddrops/objects/Drop.java
+++ b/src/main/java/dawidos506/ddrops/objects/Drop.java
@@ -5,14 +5,16 @@ import org.bukkit.inventory.ItemStack;
 public class Drop {
 
     public ItemStack drop;
+    public int id;
     public int amount;
     public double chance;
     public String name;
     public int minY;
     public int maxY;
 
-    public Drop(ItemStack drop, int amount, double chance, String name, int minY, int maxY) {
+    public Drop(ItemStack drop, int id, int amount, double chance, String name, int minY, int maxY) {
         this.drop = drop;
+        this.id = id;
         this.amount = amount;
         this.chance = chance;
         this.name = name;
@@ -22,6 +24,9 @@ public class Drop {
 
     public ItemStack getDrop() {
         return drop;
+    }
+    public int getId() {
+        return id;
     }
     public int getAmount() {
         return amount;

--- a/src/main/java/dawidos506/ddrops/objects/User.java
+++ b/src/main/java/dawidos506/ddrops/objects/User.java
@@ -39,4 +39,16 @@ public class User {
         return inv;
     }
 
+    public void setMined(int mined) {
+        this.mined = mined;
+    }
+    public void setMsg(boolean msg) {
+        this.msg = msg;
+    }
+    public void setCobble(boolean cobble) {
+        this.cobble = cobble;
+    }
+    public void setInv(boolean inv) {
+        this.inv = inv;
+    }
 }

--- a/src/main/java/dawidos506/ddrops/utils/PlayerUtils.java
+++ b/src/main/java/dawidos506/ddrops/utils/PlayerUtils.java
@@ -1,0 +1,23 @@
+package dawidos506.ddrops.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.UUID;
+
+public class PlayerUtils {
+
+    public static ItemStack getPlayerSkull(UUID uuid) {
+        ItemStack item = new ItemStack(Material.PLAYER_HEAD, 1);
+
+        SkullMeta meta = (SkullMeta) item.getItemMeta();
+        meta.setOwner(Bukkit.getOfflinePlayer(uuid).getName());
+
+        item.setItemMeta(meta);
+
+        return item;
+    }
+
+}

--- a/src/main/resources/drops.yml
+++ b/src/main/resources/drops.yml
@@ -1,11 +1,13 @@
 drops:
   IRON_INGOT:
+    id: 1
     amount: 1
     chance: 50.0
     name: 'Zelazo'
     minY: 0
     maxY: 255
   DIAMOND:
+    id: 2
     amount: 1
     chance: 25.0
     name: 'Diament'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,11 @@
 name: dDrops
-version: 1.1
+version: 1.2
 main: dawidos506.ddrops.Main
 api-version: 1.16
 prefix: dDrops
 authors: [ dawidos506 ]
 description: Plugin pozwalający na dodanie dodatkowych dropów z kamienia.
 website: https://github.com/dawidekkochany123
+
+commands:
+  drop:


### PR DESCRIPTION
### **Update 1.2**

Added: 
- New command: **/drop**
- You can now toggle:
1. items drop on ground or go to inventory
2. cobble drop
3. messages
- **List of all the drops** in the GUI (limited to 36 for now)
- Every drop has a **ID** now (will be used for future updates)

Removed:

Repaired:
